### PR TITLE
A4/Code Coverage Badge Bugfix

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -90,12 +90,8 @@ jobs:
 
       - name: Update ML Test Score Table in README
         run: |
-          awk '
-            BEGIN {start="<!-- ML_TEST_SCORE_START -->"; end="<!-- ML_TEST_SCORE_END -->"; in_block=0}
-            $0 ~ start {print; while ((getline line < "ml_test_score.md") > 0) print line; in_block=1; next}
-            $0 ~ end {in_block=0; print; next}
-            !in_block {print}
-          ' README.md > tmp_README.md
+          awk '/<!-- ML_TEST_SCORE_START -->/{print;flag=1;next}/<!-- ML_TEST_SCORE_END -->/{flag=0;print;next}!flag' README.md > tmp_README.md
+          cat ml_test_score.md >> tmp_README.md
           mv tmp_README.md README.md
 
       - name: Update ML Test Score Badge

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -85,15 +85,13 @@ jobs:
           badge="![Coverage](https://img.shields.io/badge/coverage-${coverage}%25-brightgreen?logo=codecov)"
           sed -i "/<!-- COVERAGE_BADGE_START -->/,/<!-- COVERAGE_BADGE_END -->/c\\<!-- COVERAGE_BADGE_START -->\n$badge\n<!-- COVERAGE_BADGE_END -->" README.md
 
-
       - name: Calculate ML Test Score
         run: python ml_test_score.py
 
       - name: Update ML Test Score Table in README
         run: |
-          awk '/<!-- ML_TEST_SCORE_START -->/{print;flag=1;next}/<!-- ML_TEST_SCORE_END -->/{flag=0;print;next}!flag' README.md > tmp_README.md
-          cat ml_test_score.md >> tmp_README.md
-          mv tmp_README.md README.md
+          content=$(<ml_test_score.md)
+          sed -i "/<!-- ML_TEST_SCORE_START -->/,/<!-- ML_TEST_SCORE_END -->/c\\<!-- ML_TEST_SCORE_START -->\n${content}\n<!-- ML_TEST_SCORE_END -->" README.md
 
       - name: Update ML Test Score Badge
         run: |

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -90,8 +90,13 @@ jobs:
 
       - name: Update ML Test Score Table in README
         run: |
-          content=$(<ml_test_score.md)
-          sed -i "/<!-- ML_TEST_SCORE_START -->/,/<!-- ML_TEST_SCORE_END -->/c\\<!-- ML_TEST_SCORE_START -->\n${content}\n<!-- ML_TEST_SCORE_END -->" README.md
+          awk '
+            BEGIN {start="<!-- ML_TEST_SCORE_START -->"; end="<!-- ML_TEST_SCORE_END -->"; in_block=0}
+            $0 ~ start {print; while ((getline line < "ml_test_score.md") > 0) print line; in_block=1; next}
+            $0 ~ end {in_block=0; print; next}
+            !in_block {print}
+          ' README.md > tmp_README.md
+          mv tmp_README.md README.md
 
       - name: Update ML Test Score Badge
         run: |

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Update Coverage Badge in README
         run: |
           coverage=${{ steps.coverage.outputs.coverage_percent }}
-          badge="![Coverage](https://img.shields.io/badge/coverage-${coverage}%25-brightgreen)"
+          badge="![Coverage](https://img.shields.io/badge/coverage-${coverage}%25-brightgreen?logo=codecov)"
           sed -i "/<!-- COVERAGE_BADGE_START -->/,/<!-- COVERAGE_BADGE_END -->/c\\<!-- COVERAGE_BADGE_START -->\n$badge\n<!-- COVERAGE_BADGE_END -->" README.md
 
 

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -67,11 +67,24 @@ jobs:
         with:
           files: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
+      
+      - name: Extract Coverage Percentage
+        id: coverage
+        run: |
+          coverage_line=$(grep -oP 'line-rate="\K[0-9.]+' coverage.xml | head -1)
+          if [[ -n "$coverage_line" ]]; then
+            percentage=$(awk "BEGIN {printf \"%.0f\", $coverage_line * 100}")
+          else
+            percentage="unknown"
+          fi
+          echo "coverage_percent=$percentage" >> $GITHUB_OUTPUT
 
       - name: Update Coverage Badge in README
         run: |
-          coverage_badge="![Coverage](https://codecov.io/github/remla25-team21/model-training/branch/feat%2Fa4-ml-testing/graph/badge.svg?token=L9ICV9K86O)"
-          sed -i "/<!-- COVERAGE_BADGE_START -->/,/<!-- COVERAGE_BADGE_END -->/c\\<!-- COVERAGE_BADGE_START -->\n$coverage_badge\n<!-- COVERAGE_BADGE_END -->" README.md
+          coverage=${{ steps.coverage.outputs.coverage_percent }}
+          badge="![Coverage](https://img.shields.io/badge/coverage-${coverage}%25-brightgreen)"
+          sed -i "/<!-- COVERAGE_BADGE_START -->/,/<!-- COVERAGE_BADGE_END -->/c\\<!-- COVERAGE_BADGE_START -->\n$badge\n<!-- COVERAGE_BADGE_END -->" README.md
+
 
       - name: Calculate ML Test Score
         run: python ml_test_score.py

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -66,7 +66,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
       
       - name: Extract Coverage Percentage
         id: coverage

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- PYLINT_BADGE_END -->
 
 <!-- COVERAGE_BADGE_START -->
-![Coverage](https://codecov.io/github/remla25-team21/model-training/branch/feat%2Fa4-ml-testing/graph/badge.svg?token=L9ICV9K86O)
+![Coverage](https://img.shields.io/badge/coverage-87%25-brightgreen)
 <!-- COVERAGE_BADGE_END -->
 
 <!-- ML_SCORE_BADGE_START -->

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Use Git Bash as your terminal:
 <!-- ML_TEST_SCORE_START -->
 <!-- ML_TEST_SCORE_END -->
 <!-- ML_TEST_SCORE_START -->
+<!-- ML_TEST_SCORE_END -->
+<!-- ML_TEST_SCORE_START -->
 | Category              | Test Count | Automated? |
 |-----------------------|------------|------------|
 | Feature & Data         | ✅ 5        | ✅         |

--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ Use Git Bash as your terminal:
 
 ## ML Test Score
 <!-- ML_TEST_SCORE_START -->
+<!-- ML_TEST_SCORE_END -->
+<!-- ML_TEST_SCORE_START -->
 | Category              | Test Count | Automated? |
 |-----------------------|------------|------------|
 | Feature & Data         | ✅ 5        | ✅         |

--- a/README.md
+++ b/README.md
@@ -205,13 +205,6 @@ Use Git Bash as your terminal:
 ## ML Test Score
 
 <!-- ML_TEST_SCORE_START -->
-<!-- ML_TEST_SCORE_END -->
-<!-- ML_TEST_SCORE_START -->
-<!-- ML_TEST_SCORE_END -->
-<!-- ML_TEST_SCORE_START -->
-<!-- ML_TEST_SCORE_END -->
-<!-- ML_TEST_SCORE_START -->
-<!-- ML_TEST_SCORE_END -->
 <!-- ML_TEST_SCORE_START -->
 | Category              | Test Count | Automated? |
 |-----------------------|------------|------------|
@@ -225,4 +218,13 @@ Use Git Bash as your terminal:
 | Evaluation Module      | ✅ 4        | ✅         |
 
 **Final Score:** 12/12
+<!-- ML_TEST_SCORE_END -->
+<!-- ML_TEST_SCORE_END -->
+<!-- ML_TEST_SCORE_START -->
+<!-- ML_TEST_SCORE_END -->
+<!-- ML_TEST_SCORE_START -->
+<!-- ML_TEST_SCORE_END -->
+<!-- ML_TEST_SCORE_START -->
+<!-- ML_TEST_SCORE_END -->
+<!-- ML_TEST_SCORE_START -->
 <!-- ML_TEST_SCORE_END -->

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- PYLINT_BADGE_END -->
 
 <!-- COVERAGE_BADGE_START -->
-![Coverage](https://img.shields.io/badge/coverage-87%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-97%25-brightgreen)
 <!-- COVERAGE_BADGE_END -->
 
 <!-- ML_SCORE_BADGE_START -->
@@ -204,6 +204,8 @@ Use Git Bash as your terminal:
 
 ## ML Test Score
 
+<!-- ML_TEST_SCORE_START -->
+<!-- ML_TEST_SCORE_END -->
 <!-- ML_TEST_SCORE_START -->
 <!-- ML_TEST_SCORE_END -->
 <!-- ML_TEST_SCORE_START -->

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- PYLINT_BADGE_END -->
 
 <!-- COVERAGE_BADGE_START -->
-![Coverage](https://img.shields.io/badge/coverage-97%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-97%25-brightgreen?logo=codecov)
 <!-- COVERAGE_BADGE_END -->
 
 <!-- ML_SCORE_BADGE_START -->
@@ -204,6 +204,8 @@ Use Git Bash as your terminal:
 
 ## ML Test Score
 
+<!-- ML_TEST_SCORE_START -->
+<!-- ML_TEST_SCORE_END -->
 <!-- ML_TEST_SCORE_START -->
 <!-- ML_TEST_SCORE_END -->
 <!-- ML_TEST_SCORE_START -->

--- a/README.md
+++ b/README.md
@@ -203,8 +203,6 @@ Use Git Bash as your terminal:
 ```
 
 ## ML Test Score
-
-<!-- ML_TEST_SCORE_START -->
 <!-- ML_TEST_SCORE_START -->
 | Category              | Test Count | Automated? |
 |-----------------------|------------|------------|
@@ -218,13 +216,4 @@ Use Git Bash as your terminal:
 | Evaluation Module      | ✅ 4        | ✅         |
 
 **Final Score:** 12/12
-<!-- ML_TEST_SCORE_END -->
-<!-- ML_TEST_SCORE_END -->
-<!-- ML_TEST_SCORE_START -->
-<!-- ML_TEST_SCORE_END -->
-<!-- ML_TEST_SCORE_START -->
-<!-- ML_TEST_SCORE_END -->
-<!-- ML_TEST_SCORE_START -->
-<!-- ML_TEST_SCORE_END -->
-<!-- ML_TEST_SCORE_START -->
 <!-- ML_TEST_SCORE_END -->


### PR DESCRIPTION
The previous badge was using directly from CodeCov with the token, which might be the issue for this bug:
![image](https://github.com/user-attachments/assets/bd24a11d-89c3-4b0f-8743-a21a2640a842)
![image](https://github.com/user-attachments/assets/6212b6dc-a17c-4d8a-a2fb-3330958042d1)

I recommend generating the badge using shields.io, which is more reliable.